### PR TITLE
fix(alignment-from-stt): Support automated transcriptions with just one segment

### DIFF
--- a/src/alignment-from-stt/alignement/index.js
+++ b/src/alignment-from-stt/alignement/index.js
@@ -84,7 +84,7 @@ function align(accurateBaseText, automatedTranscription, textAttributeName = 'te
         // handling last line of input
         if(automatedTranscription.length-1 === i){
             // just to make sure the line is not already in there 
-            if(transcript[transcript.length-1].text!==accurateBaseTextLines[currentLineCounter]){
+            if(transcript.length < 1 || (transcript[transcript.length-1].text!==accurateBaseTextLines[currentLineCounter])){
                 transcript.push({
                     start: currentStart,
                     end: currentWord.end,

--- a/src/alignment-from-stt/alignement/index.test.js
+++ b/src/alignment-from-stt/alignement/index.test.js
@@ -2750,3 +2750,79 @@ test.skip('align automated text with timecodes with correct text no timecodes', 
 
     expect(reAlignedTranscription).toEqual(expectedOutput);
 });
+
+it('Should work with one-paragraph transcriptions', () => {
+    const accurateBase = "Testing testing. This is the first sentence. This is the second sentence.";
+    const automatedTranscription = [
+        {
+            "end": 2.3,
+            "start": 1.9,
+            "text": "Testing"
+        },
+        {
+            "end": 3.7,
+            "start": 2.3,
+            "text": "testing."
+        },
+        {
+            "end": 3.9,
+            "start": 3.7,
+            "text": "This"
+        },
+        {
+            "end": 4.1,
+            "start": 3.9,
+            "text": "is"
+        },
+        {
+            "end": 4.2,
+            "start": 4.1,
+            "text": "the"
+        },
+        {
+            "end": 4.6,
+            "start": 4.2,
+            "text": "first"
+        },
+        {
+            "end": 6.1,
+            "start": 4.6,
+            "text": "sentence."
+        },
+        {
+            "end": 6.3,
+            "start": 6.1,
+            "text": "This"
+        },
+        {
+            "end": 6.4,
+            "start": 6.3,
+            "text": "is"
+        },
+        {
+            "end": 6.6,
+            "start": 6.4,
+            "text": "the"
+        },
+        {
+            "end": 6.9,
+            "start": 6.6,
+            "text": "second"
+        },
+        {
+            "start": 6.9,
+            "end": 7.6,
+            "text": "sentence."
+        }
+    ];
+
+    const tracked = jest.fn(() => align(accurateBase, automatedTranscription, "text", false))
+    tracked();
+    expect(tracked).toReturnWith([
+        {
+            "start": 1.9,
+            "end": 7.6,
+            "text": "Testing testing. This is the first sentence. This is the second sentence."
+        }
+    ])
+})


### PR DESCRIPTION
**Describe what the PR does**    
I noticed that when I provide just a single segment to `align-from-stt`, there was an error because `transcript` had no entries in it. This fixes that error.

**State whether the PR is ready for review or whether it needs extra work**    
Ready! 😁 Also has associated unit test